### PR TITLE
fix: remove api call to vali to get miners

### DIFF
--- a/storb/protocol.py
+++ b/storb/protocol.py
@@ -68,6 +68,7 @@ class MetadataResponse(BaseModel):
 
 
 class GetMinersBase(BaseModel):
+    filename: str
     infohash: str
     chunk_ids: Optional[list[str]] = Field(default=None)
     chunks_metadata: Optional[list[ChunkDHTValue]] = Field(
@@ -76,11 +77,3 @@ class GetMinersBase(BaseModel):
     pieces_metadata: Optional[list[list[PieceDHTValue]]] = Field(
         default=None
     )  # multi dimensional array of piece metadata. each row corresponds to a chunk
-
-
-class GetMiners(GetMinersBase):
-    def __str__(self) -> str:
-        return f"GetMiners(infohash={self.infohash}, \
-            chunk_ids={self.chunk_ids}, \
-            chunks_metadata={self.chunks_metadata}, \
-            pieces_metadata={self.pieces_metadata})"

--- a/storb/validator/validator.py
+++ b/storb/validator/validator.py
@@ -14,7 +14,7 @@ from typing import AsyncGenerator, Literal, override
 import httpx
 import numpy as np
 import uvicorn
-from fastapi import Body, File, HTTPException, UploadFile
+from fastapi import File, HTTPException, UploadFile
 from fastapi.responses import StreamingResponse
 from fiber.chain import interface
 from fiber.chain.weights import set_node_weights


### PR DESCRIPTION
**Notable Changes:**
Remove call to `/miners` to get miners and other piece and chunk data, instead the vali looks in the DHT by itself